### PR TITLE
Add support for manifest property thumbnail

### DIFF
--- a/app/iiif_parser.js
+++ b/app/iiif_parser.js
@@ -298,4 +298,22 @@ export default class IIIFParser {
 
     return subtitlesObj
   }
+
+  /**
+   * Get a thumbnail (poster) to display for a video file if one exists in the manifest
+   * @param  {Object} manifest The manifest
+   * @return {string} URI of thumbnail or an empty string if not found
+   */
+  getThumbnail (manifest) {
+    let thumbnail = ''
+
+    if (manifest.hasOwnProperty('sequences')) {
+      if (manifest.sequences[0].hasOwnProperty('items')) {
+        if (manifest.sequences[0].items[0].hasOwnProperty('thumbnail')) {
+          thumbnail = manifest.sequences[0].items[0].thumbnail.id
+        }
+      }
+    }
+    return thumbnail
+  }
 }

--- a/app/iiif_player.js
+++ b/app/iiif_player.js
@@ -71,6 +71,7 @@ export default class IIIFPlayer {
       this.toggleAlertMessage('', false)
     })
 
+    // Slide toggle the DOM section which displays current manifest JSON object
     $currentManifest.find('h4').on('click', (e) => {
       $currentManifest.find('pre').slideToggle()
     })

--- a/app/player.js
+++ b/app/player.js
@@ -101,17 +101,19 @@ export default class Player {
     let markup = ''
     let subtitlesObj = this.iiifParser.getSubtitles(contentObj)
     let dimensions = this.iiifParser.getPlayerDimensions(this.manifest, contentObj, item)
+    let videoSourceFormat = item.format || 'video/mp4'
+    let audioSourceFormat = item.format || 'audio/mp3'
 
     // Audio File
     if (item.type === 'Audio') {
       markup = `<audio width="100%" controls id="${this.playerElId}" data-mejsoptions='{"stretching": "responsive"}'>
-          <source src="${item.id}" type="audio/mp3" data-quality="${item.label}">
+          <source src="${item.id}" type="${audioSourceFormat}" data-quality="${item.label}">
         </audio>`
     }
     // Video File
     if (item.type === 'Video') {
-      markup = `<video class="av-player-controls" id="${this.playerElId}" class="mejs__player" height="${dimensions.height}" width="${dimensions.width}" controls data-mejsoptions='{"pluginPath": "", "alwaysShowControls": "true"}'>
-          <source src="${item.id}" type="video/mp4">
+      markup = `<video class="av-player-controls" id="${this.playerElId}" height="${dimensions.height}" width="${dimensions.width}" controls>
+          <source src="${item.id}" type="${videoSourceFormat}">
           <track kind="subtitles" src="${subtitlesObj.id}" srclang="${subtitlesObj.language}">
         </video>`
     }
@@ -140,7 +142,10 @@ export default class Player {
   render (contentObj, qualityLevel = 'Medium') {
     // Get current item in manifest to render
     let item = this.iiifParser.getContentItem(contentObj, qualityLevel)
-
+    let defaults = {
+      alwaysShowControls: true,
+      pluginPath: ''
+    }
     // Generate HTML5 markup which Mediaelement will hook into
     let playerMarkup = this.generatePlayerMarkup(contentObj, item)
 
@@ -156,8 +161,16 @@ export default class Player {
     // Insert HTML5 tag markup
     document.getElementById(this.configObj.playerWrapperId).innerHTML = playerMarkup
 
+    // Add poster image (if one exists) for video files
+    if (this.currentPlayerType === 'Video') {
+      let thumbnail = this.iiifParser.getThumbnail(this.manifest)
+      if (thumbnail !== '') {
+        defaults.poster = thumbnail
+      }
+    }
+
     // Instantiate MediaElement player
-    this.player = new MediaElementPlayer(this.playerElId, {}) // eslint-disable-line
+    this.player = new MediaElementPlayer(this.playerElId, defaults) // eslint-disable-line
 
     // This enables the custom quality selector
     // TODO: Fix this if we want it working


### PR DESCRIPTION
Add initial, targeted support for video poster image based on manifest property: thumbnail.  

Note this is very targeted (in this commit) to work with a structure similar to this manifest: http://dlib.indiana.edu/iiif_av/lunchroom_manners/lunchroom_manners_v4.json

As we further clarify how `thumbnail` is used within an Avalon (or broader?) context, the parsing and retrieval of this value should cast a wider net.